### PR TITLE
Modify permissions so that query api can be used without authentication

### DIFF
--- a/src/main/kotlin/com/jaranda/goorlebackend/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/jaranda/goorlebackend/config/SecurityConfig.kt
@@ -5,6 +5,7 @@ import com.jaranda.goorlebackend.shared.security.handler.JarandaAccessDeniedHand
 import com.jaranda.goorlebackend.shared.security.handler.JarandaAuthenticationEntryPoint
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -38,6 +39,13 @@ class SecurityConfig(
                 auth
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                     .requestMatchers("/api/v1/auth/login").permitAll()
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/api/v1/user/me",
+                        "/api/v1/accommodations/me",
+                        "/api/v1/comments/me"
+                    ).authenticated()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/**").permitAll()
                     .requestMatchers("/api/v1/**").authenticated()
                     .anyRequest().denyAll()
             }


### PR DESCRIPTION
기존의 GET 요청의 요청 권한 레벨을 하향했습니다. 
원래 조회를 할 때에도 인증/인가가 적용되어야 했지만 해당 부분이 불필요하다고 판단했기 때문입니다.